### PR TITLE
Add base64 encoding option for keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6310,10 +6310,11 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.8.0"
+version = "0.8.0-chron.1"
 dependencies = [
  "ansi_term 0.12.1",
  "atty",
+ "base64 0.12.3",
  "bip39",
  "chrono",
  "derive_more",
@@ -6881,7 +6882,7 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.8.0"
+version = "0.8.0-chron.1"
 dependencies = [
  "assert_matches",
  "async-std",
@@ -7132,7 +7133,7 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.8.0"
+version = "0.8.0-chron.1"
 dependencies = [
  "async-std",
  "derive_more",

--- a/bin/node-template/node/Cargo.toml
+++ b/bin/node-template/node/Cargo.toml
@@ -18,10 +18,10 @@ name = "node-template"
 [dependencies]
 structopt = "0.3.8"
 
-sc-cli = { version = "0.8.0", path = "../../../client/cli", features = ["wasmtime"] }
+sc-cli = { version = "0.8.0-chron.1", path = "../../../client/cli", features = ["wasmtime"] }
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
 sc-executor = { version = "0.8.0", path = "../../../client/executor", features = ["wasmtime"] }
-sc-service = { version = "0.8.0", path = "../../../client/service", features = ["wasmtime"] }
+sc-service = { version = "0.8.0-chron.1", path = "../../../client/service", features = ["wasmtime"] }
 sp-inherents = { version = "2.0.0", path = "../../../primitives/inherents" }
 sc-transaction-pool = { version = "2.0.0", path = "../../../client/transaction-pool" }
 sp-transaction-pool = { version = "2.0.0", path = "../../../primitives/transaction-pool" }

--- a/bin/node/bench/Cargo.toml
+++ b/bin/node/bench/Cargo.toml
@@ -13,7 +13,7 @@ log = "0.4.8"
 node-primitives = { version = "2.0.0", path = "../primitives" }
 node-testing = { version = "2.0.0", path = "../testing" }
 node-runtime = { version = "2.0.0", path = "../runtime" }
-sc-cli = { version = "0.8.0", path = "../../../client/cli" }
+sc-cli = { version = "0.8.0-chron.1", path = "../../../client/cli" }
 sc-client-api = { version = "2.0.0", path = "../../../client/api/" }
 sp-runtime = { version = "2.0.0", path = "../../../primitives/runtime" }
 sp-state-machine = { version = "0.8.0", path = "../../../primitives/state-machine" }

--- a/bin/node/cli/Cargo.toml
+++ b/bin/node/cli/Cargo.toml
@@ -63,14 +63,14 @@ sc-client-api = { version = "2.0.0", path = "../../../client/api" }
 sc-chain-spec = { version = "2.0.0", path = "../../../client/chain-spec" }
 sc-consensus = { version = "0.8.0", path = "../../../client/consensus/common" }
 sc-transaction-pool = { version = "2.0.0", path = "../../../client/transaction-pool" }
-sc-network = { version = "0.8.0", path = "../../../client/network" }
+sc-network = { version = "0.8.0-chron.1", path = "../../../client/network" }
 sc-consensus-babe = { version = "0.8.0", path = "../../../client/consensus/babe" }
 grandpa = { version = "0.8.0", package = "sc-finality-grandpa", path = "../../../client/finality-grandpa" }
 sc-client-db = { version = "0.8.0", default-features = false, path = "../../../client/db" }
 sc-offchain = { version = "2.0.0", path = "../../../client/offchain" }
 sc-rpc = { version = "2.0.0", path = "../../../client/rpc" }
 sc-basic-authorship = { version = "0.8.0", path = "../../../client/basic-authorship" }
-sc-service = { version = "0.8.0", default-features = false, path = "../../../client/service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../../../client/service" }
 sc-tracing = { version = "2.0.0", path = "../../../client/tracing" }
 sc-telemetry = { version = "2.0.0", path = "../../../client/telemetry" }
 sc-authority-discovery = { version = "0.8.0",  path = "../../../client/authority-discovery" }
@@ -95,7 +95,7 @@ node-primitives = { version = "2.0.0", path = "../primitives" }
 node-executor = { version = "2.0.0", path = "../executor" }
 
 # CLI-specific dependencies
-sc-cli = { version = "0.8.0", optional = true, path = "../../../client/cli" }
+sc-cli = { version = "0.8.0-chron.1", optional = true, path = "../../../client/cli" }
 frame-benchmarking-cli = { version = "2.0.0", optional = true, path = "../../../utils/frame/benchmarking-cli" }
 node-inspect = { version = "0.8.0", optional = true, path = "../inspect" }
 
@@ -106,8 +106,8 @@ browser-utils = { package = "substrate-browser-utils", path = "../../../utils/br
 
 [target.'cfg(target_arch="x86_64")'.dependencies]
 node-executor = { version = "2.0.0", path = "../executor", features = [ "wasmtime" ] }
-sc-cli = { version = "0.8.0", optional = true, path = "../../../client/cli", features = [ "wasmtime" ] }
-sc-service = { version = "0.8.0", default-features = false, path = "../../../client/service", features = [ "wasmtime" ] }
+sc-cli = { version = "0.8.0-chron.1", optional = true, path = "../../../client/cli", features = [ "wasmtime" ] }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../../../client/service", features = [ "wasmtime" ] }
 sp-trie = { version = "2.0.0", default-features = false, path = "../../../primitives/trie", features = ["memory-tracker"] }
 
 [dev-dependencies]
@@ -132,7 +132,7 @@ substrate-build-script-utils = { version = "2.0.0", optional = true, path = "../
 substrate-frame-cli = { version = "2.0.0", optional = true, path = "../../../utils/frame/frame-utilities-cli" }
 
 [build-dependencies.sc-cli]
-version = "0.8.0"
+version = "0.8.0-chron.1"
 package = "sc-cli"
 path = "../../../client/cli"
 optional = true

--- a/bin/node/inspect/Cargo.toml
+++ b/bin/node/inspect/Cargo.toml
@@ -14,9 +14,9 @@ targets = ["x86_64-unknown-linux-gnu"]
 codec = { package = "parity-scale-codec", version = "1.3.4" }
 derive_more = "0.99"
 log = "0.4.8"
-sc-cli = { version = "0.8.0", path = "../../../client/cli" }
+sc-cli = { version = "0.8.0-chron.1", path = "../../../client/cli" }
 sc-client-api = { version = "2.0.0", path = "../../../client/api" }
-sc-service = { version = "0.8.0", default-features = false, path = "../../../client/service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../../../client/service" }
 sp-blockchain = { version = "2.0.0", path = "../../../primitives/blockchain" }
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
 sp-runtime = { version = "2.0.0", path = "../../../primitives/runtime" }

--- a/bin/node/testing/Cargo.toml
+++ b/bin/node/testing/Cargo.toml
@@ -14,7 +14,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 pallet-balances = { version = "2.0.0", path = "../../../frame/balances" }
-sc-service = { version = "0.8.0", features = ["test-helpers", "db"],  path = "../../../client/service" }
+sc-service = { version = "0.8.0-chron.1", features = ["test-helpers", "db"],  path = "../../../client/service" }
 sc-client-db = { version = "0.8.0", path = "../../../client/db/", features = ["kvdb-rocksdb", "parity-db"] }
 sc-client-api = { version = "2.0.0", path = "../../../client/api/" }
 codec = { package = "parity-scale-codec", version = "1.3.4" }
@@ -53,4 +53,4 @@ futures = "0.3.1"
 
 [dev-dependencies]
 criterion = "0.3.0"
-sc-cli = { version = "0.8.0", path = "../../../client/cli" }
+sc-cli = { version = "0.8.0-chron.1", path = "../../../client/cli" }

--- a/bin/utils/subkey/Cargo.toml
+++ b/bin/utils/subkey/Cargo.toml
@@ -18,7 +18,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 node-runtime = { version = "2.0.0", path = "../../node/runtime" }
 node-primitives = { version = "2.0.0", path = "../../node/primitives" }
-sc-cli = { version = "0.8.0", path = "../../../client/cli" }
+sc-cli = { version = "0.8.0-chron.1", path = "../../../client/cli" }
 substrate-frame-cli = { version = "2.0.0", path = "../../../utils/frame/frame-utilities-cli" }
 structopt = "0.3.14"
 frame-system = { version = "2.0.0", path = "../../../frame/system" }

--- a/client/authority-discovery/Cargo.toml
+++ b/client/authority-discovery/Cargo.toml
@@ -30,7 +30,7 @@ prost = "0.6.1"
 rand = "0.7.2"
 sc-client-api = { version = "2.0.0", path = "../api" }
 sc-keystore = { version = "2.0.0", path = "../keystore" }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 serde_json = "1.0.41"
 sp-authority-discovery = { version = "2.0.0", path = "../../primitives/authority-discovery" }
 sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }

--- a/client/chain-spec/Cargo.toml
+++ b/client/chain-spec/Cargo.toml
@@ -15,7 +15,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 sc-chain-spec-derive = { version = "2.0.0", path = "./derive" }
 impl-trait-for-tuples = "0.1.3"
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sp-core = { version = "2.0.0", path = "../../primitives/core" }
 serde = { version = "1.0.101", features = ["derive"] }
 serde_json = "1.0.41"

--- a/client/cli/Cargo.toml
+++ b/client/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-cli"
-version = "0.8.0"
+version = "0.8.0-chron.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 description = "Substrate CLI interface."
 edition = "2018"
@@ -13,6 +13,7 @@ readme = "README.md"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
+base64 = "0.12.3"
 derive_more = "0.99.2"
 log = "0.4.8"
 atty = "0.2.13"
@@ -34,12 +35,12 @@ sc-informant = { version = "0.8.0", path = "../informant" }
 sp-panic-handler = { version = "2.0.0", path = "../../primitives/panic-handler" }
 sc-client-api = { version = "2.0.0", path = "../api" }
 sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 sp-utils = { version = "2.0.0", path = "../../primitives/utils" }
 sp-version = { version = "2.0.0", path = "../../primitives/version" }
 sp-core = { version = "2.0.0", path = "../../primitives/core" }
-sc-service = { version = "0.8.0", default-features = false, path = "../service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../service" }
 sp-state-machine = { version = "0.8.0", path = "../../primitives/state-machine" }
 sc-telemetry = { version = "2.0.0", path = "../telemetry" }
 substrate-prometheus-endpoint = { path = "../../utils/prometheus" , version = "0.8.0"}

--- a/client/cli/src/params/node_key_params.rs
+++ b/client/cli/src/params/node_key_params.rs
@@ -16,6 +16,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
+use base64;
 use sc_network::{config::identity::ed25519, config::NodeKeyConfig};
 use sp_core::H256;
 use std::{path::PathBuf, str::FromStr};
@@ -49,6 +50,13 @@ pub struct NodeKeyParams {
 	/// an externally managed secret key, use `--node-key-file` instead.
 	#[structopt(long = "node-key", value_name = "KEY")]
 	pub node_key: Option<String>,
+
+	/// Enable base64 encoding of the secret key
+	///
+	/// If not specified the node-key should be specified in Hexadecimal.
+	/// By default this flag is not set,
+	#[structopt(long = "node-key-base64")]
+	pub node_key_base64: bool,
 
 	/// The type of secret key to use for libp2p networking.
 	///
@@ -98,7 +106,12 @@ impl NodeKeyParams {
 		Ok(match self.node_key_type {
 			NodeKeyType::Ed25519 => {
 				let secret = if let Some(node_key) = self.node_key.as_ref() {
-					parse_ed25519_secret(node_key)?
+					if self.node_key_base64 {
+						let key_bytes = base64::decode(node_key).expect("The node key is not a valid base64 encoding");
+						parse_ed25519_secret_base64(key_bytes)?
+					} else {
+						parse_ed25519_secret(node_key)?
+					}
 				} else {
 					sc_network::config::Secret::File(
 						self.node_key_file
@@ -120,13 +133,20 @@ fn invalid_node_key(e: impl std::fmt::Display) -> error::Error {
 
 /// Parse a Ed25519 secret key from a hex string into a `sc_network::Secret`.
 fn parse_ed25519_secret(hex: &str) -> error::Result<sc_network::config::Ed25519Secret> {
-	H256::from_str(&hex)
-		.map_err(invalid_node_key)
-		.and_then(|bytes| {
-			ed25519::SecretKey::from_bytes(bytes)
-				.map(sc_network::config::Secret::Input)
-				.map_err(invalid_node_key)
-		})
+		H256::from_str(&hex)
+			.map_err(invalid_node_key)
+			.and_then(|bytes| {
+				sc_network::config::identity::ed25519::SecretKey::from_bytes(bytes)
+					.map(sc_network::config::Secret::Input)
+					.map_err(invalid_node_key)
+			})
+}
+
+/// Parse a Ed25519 secret key from a basee64 string into a `sc_network::Secret`.
+fn parse_ed25519_secret_base64(mut key_bytes: Vec<u8>) -> error::Result<sc_network::config::Ed25519Secret> {
+		sc_network::config::identity::ed25519::SecretKey::from_bytes(key_bytes.as_mut_slice())
+			.map(sc_network::config::Secret::Input)
+			.map_err(invalid_node_key)
 }
 
 #[cfg(test)]

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -42,8 +42,8 @@ prometheus-endpoint = { package = "substrate-prometheus-endpoint", path = "../..
 sp-keyring = { version = "2.0.0", path = "../../../primitives/keyring" }
 sp-tracing = { version = "2.0.0", path = "../../../primitives/tracing" }
 sc-executor = { version = "0.8.0", path = "../../executor" }
-sc-network = { version = "0.8.0", path = "../../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
-sc-service = { version = "0.8.0", default-features = false, path = "../../service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../../service" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 tempfile = "3.1.0"

--- a/client/consensus/babe/Cargo.toml
+++ b/client/consensus/babe/Cargo.toml
@@ -56,9 +56,9 @@ retain_mut = "0.1.1"
 sp-keyring = { version = "2.0.0", path = "../../../primitives/keyring" }
 sp-tracing = { version = "2.0.0", path = "../../../primitives/tracing" }
 sc-executor = { version = "0.8.0", path = "../../executor" }
-sc-network = { version = "0.8.0", path = "../../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../../network" }
 sc-network-test = { version = "0.8.0", path = "../../network/test" }
-sc-service = { version = "0.8.0", default-features = false, path = "../../service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../../service" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils/runtime/client" }
 sc-block-builder = { version = "0.8.0", path = "../../block-builder" }
 rand_chacha = "0.2.2"

--- a/client/finality-grandpa/Cargo.toml
+++ b/client/finality-grandpa/Cargo.toml
@@ -37,7 +37,7 @@ serde_json = "1.0.41"
 sc-client-api = { version = "2.0.0", path = "../api" }
 sp-inherents = { version = "2.0.0", path = "../../primitives/inherents" }
 sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sc-network-gossip = { version = "0.8.0", path = "../network-gossip" }
 sp-finality-tracker = { version = "2.0.0", path = "../../primitives/finality-tracker" }
 sp-finality-grandpa = { version = "2.0.0", path = "../../primitives/finality-grandpa" }
@@ -49,7 +49,7 @@ pin-project = "0.4.6"
 [dev-dependencies]
 assert_matches = "1.3.0"
 finality-grandpa = { version = "0.12.3", features = ["derive-codec", "test-helpers"] }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sc-network-test = { version = "0.8.0", path = "../network/test" }
 sp-keyring = { version = "2.0.0", path = "../../primitives/keyring" }
 substrate-test-runtime-client = { version = "2.0.0",  path = "../../test-utils/runtime/client" }

--- a/client/informant/Cargo.toml
+++ b/client/informant/Cargo.toml
@@ -18,7 +18,7 @@ futures = "0.3.4"
 log = "0.4.8"
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
 sc-client-api = { version = "2.0.0", path = "../api" }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 sp-utils = { version = "2.0.0", path = "../../primitives/utils" }

--- a/client/network-gossip/Cargo.toml
+++ b/client/network-gossip/Cargo.toml
@@ -20,7 +20,7 @@ futures-timer = "3.0.1"
 libp2p = { version = "0.28.1", default-features = false }
 log = "0.4.8"
 lru = "0.4.3"
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 wasm-timer = "0.2"
 

--- a/client/network/Cargo.toml
+++ b/client/network/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 description = "Substrate network protocol"
 name = "sc-network"
-version = "0.8.0"
+version = "0.8.0-chron.1"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"

--- a/client/network/src/protocol/generic_proto/upgrade/legacy.rs
+++ b/client/network/src/protocol/generic_proto/upgrade/legacy.rs
@@ -251,7 +251,7 @@ where TSubstream: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 		Box::pin(async move {
 			let mut framed = {
 				let mut codec = UviBytes::default();
-				codec.set_max_len(16 * 1024 * 1024);		// 16 MiB hard limit for packets.
+				codec.set_max_len(32 * 1024 * 1024);		// 32 MiB hard limit for packets.
 				Framed::new(socket, codec)
 			};
 

--- a/client/network/test/Cargo.toml
+++ b/client/network/test/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/paritytech/substrate/"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-sc-network = { version = "0.8.0", path = "../" }
+sc-network = { version = "0.8.0-chron.1", path = "../" }
 log = "0.4.8"
 parking_lot = "0.10.0"
 futures = "0.3.4"
@@ -32,4 +32,4 @@ substrate-test-runtime-client = { version = "2.0.0", path = "../../../test-utils
 substrate-test-runtime = { version = "2.0.0", path = "../../../test-utils/runtime" }
 tempfile = "3.1.0"
 sp-tracing = { version = "2.0.0", path = "../../../primitives/tracing" }
-sc-service = { version = "0.8.0", default-features = false, features = ["test-helpers"],  path = "../../service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, features = ["test-helpers"],  path = "../../service" }

--- a/client/offchain/Cargo.toml
+++ b/client/offchain/Cargo.toml
@@ -29,7 +29,7 @@ sp-core = { version = "2.0.0", path = "../../primitives/core" }
 rand = "0.7.2"
 sp-runtime = { version = "2.0.0", path = "../../primitives/runtime" }
 sp-utils = { version = "2.0.0", path = "../../primitives/utils" }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sc-keystore = { version = "2.0.0", path = "../keystore" }
 
 [target.'cfg(not(target_os = "unknown"))'.dependencies]

--- a/client/rpc/Cargo.toml
+++ b/client/rpc/Cargo.toml
@@ -43,7 +43,7 @@ lazy_static = { version = "1.4.0", optional = true }
 [dev-dependencies]
 assert_matches = "1.3.0"
 futures01 = { package = "futures", version = "0.1.29" }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sp-io = { version = "2.0.0", path = "../../primitives/io" }
 substrate-test-runtime-client = { version = "2.0.0", path = "../../test-utils/runtime/client" }
 tokio = "0.1.22"

--- a/client/service/Cargo.toml
+++ b/client/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-service"
-version = "0.8.0"
+version = "0.8.0-chron.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2018"
 license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
@@ -55,7 +55,7 @@ sp-state-machine = { version = "0.8.0", path = "../../primitives/state-machine" 
 sp-application-crypto = { version = "2.0.0", path = "../../primitives/application-crypto" }
 sp-consensus = { version = "0.8.0", path = "../../primitives/consensus/common" }
 sp-inherents = { version = "2.0.0", path = "../../primitives/inherents" }
-sc-network = { version = "0.8.0", path = "../network" }
+sc-network = { version = "0.8.0-chron.1", path = "../network" }
 sc-chain-spec = { version = "2.0.0", path = "../chain-spec" }
 sc-light = { version = "2.0.0", path = "../light" }
 sc-client-api = { version = "2.0.0", path = "../api" }

--- a/client/service/src/client/client.rs
+++ b/client/service/src/client/client.rs
@@ -947,7 +947,7 @@ impl<B, E, Block, RA> Client<B, E, Block, RA> where
 		if notify {
 			// sometimes when syncing, tons of blocks can be finalized at once.
 			// we'll send notifications spuriously in that case.
-			const MAX_TO_NOTIFY: usize = 256;
+			const MAX_TO_NOTIFY: usize = 128;
 			let enacted = route_from_finalized.enacted();
 			let start = enacted.len() - std::cmp::min(enacted.len(), MAX_TO_NOTIFY);
 			for finalized in &enacted[start..] {

--- a/client/service/test/Cargo.toml
+++ b/client/service/test/Cargo.toml
@@ -28,8 +28,8 @@ sp-trie = { version = "2.0.0", path = "../../../primitives/trie" }
 sp-storage = { version = "2.0.0", path = "../../../primitives/storage" }
 sc-client-db = { version = "0.8.0", default-features = false, path = "../../db" }
 futures = { version = "0.3.1", features = ["compat"] }
-sc-service = { version = "0.8.0", default-features = false, features = ["test-helpers"], path = "../../service" }
-sc-network = { version = "0.8.0", path = "../../network" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, features = ["test-helpers"], path = "../../service" }
+sc-network = { version = "0.8.0-chron.1", path = "../../network" }
 sp-consensus = { version = "0.8.0", path = "../../../primitives/consensus/common" }
 sp-runtime = { version = "2.0.0", path = "../../../primitives/runtime" }
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -17,5 +17,5 @@ substrate-test-utils-derive = { version = "0.8.0", path = "./derive" }
 tokio = { version = "0.2.13", features = ["macros"] }
 
 [dev-dependencies]
-sc-service = { version = "0.8.0", path = "../client/service" }
+sc-service = { version = "0.8.0-chron.1", path = "../client/service" }
 trybuild = { version = "1.0", features = ["diff"] }

--- a/test-utils/client/Cargo.toml
+++ b/test-utils/client/Cargo.toml
@@ -24,7 +24,7 @@ sc-client-db = { version = "0.8.0", features = ["test-helpers"], path = "../../c
 sc-consensus = { version = "0.8.0", path = "../../client/consensus/common" }
 sc-executor = { version = "0.8.0", path = "../../client/executor" }
 sc-light = { version = "2.0.0", path = "../../client/light" }
-sc-service = { version = "0.8.0", default-features = false, features = ["test-helpers"],  path = "../../client/service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, features = ["test-helpers"],  path = "../../client/service" }
 sp-blockchain = { version = "2.0.0", path = "../../primitives/blockchain" }
 sp-consensus = { version = "0.8.0", path = "../../primitives/consensus/common" }
 sp-core = { version = "2.0.0", path = "../../primitives/core" }

--- a/test-utils/runtime/Cargo.toml
+++ b/test-utils/runtime/Cargo.toml
@@ -41,7 +41,7 @@ sp-trie = { version = "2.0.0", default-features = false, path = "../../primitive
 sp-transaction-pool = { version = "2.0.0", default-features = false, path = "../../primitives/transaction-pool" }
 trie-db = { version = "0.22.0", default-features = false }
 parity-util-mem = { version = "0.7.0", default-features = false, features = ["primitive-types"] }
-sc-service = { version = "0.8.0", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, optional = true, features = ["test-helpers"], path = "../../client/service" }
 sp-state-machine = { version = "0.8.0", default-features = false, path = "../../primitives/state-machine" }
 sp-externalities = { version = "0.8.0", default-features = false, path = "../../primitives/externalities" }
 

--- a/test-utils/runtime/client/Cargo.toml
+++ b/test-utils/runtime/client/Cargo.toml
@@ -24,5 +24,5 @@ sp-blockchain = { version = "2.0.0", path = "../../../primitives/blockchain" }
 codec = { package = "parity-scale-codec", version = "1.3.1" }
 sc-client-api = { version = "2.0.0", path = "../../../client/api" }
 sc-consensus = { version = "0.8.0", path = "../../../client/consensus/common" }
-sc-service = { version = "0.8.0", default-features = false, path = "../../../client/service" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../../../client/service" }
 futures = "0.3.4"

--- a/test-utils/test-crate/Cargo.toml
+++ b/test-utils/test-crate/Cargo.toml
@@ -14,4 +14,4 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dev-dependencies]
 tokio = { version = "0.2.13", features = ["macros"] }
 test-utils = { version = "2.0.0", path = "..", package = "substrate-test-utils" }
-sc-service = { version = "0.8.0", path = "../../client/service" }
+sc-service = { version = "0.8.0-chron.1", path = "../../client/service" }

--- a/utils/browser/Cargo.toml
+++ b/utils/browser/Cargo.toml
@@ -25,8 +25,8 @@ wasm-bindgen-futures = "0.4.7"
 kvdb-web = "0.7"
 sp-database = { version = "2.0.0", path = "../../primitives/database" }
 sc-informant = { version = "0.8.0", path = "../../client/informant" }
-sc-service = { version = "0.8.0", path = "../../client/service", default-features = false }
-sc-network = { path = "../../client/network", version = "0.8.0"}
+sc-service = { version = "0.8.0-chron.1", path = "../../client/service", default-features = false }
+sc-network = { path = "../../client/network", version = "0.8.0-chron.1"}
 sc-chain-spec = { path = "../../client/chain-spec", version = "2.0.0"}
 
 # Imported just for the `wasm-bindgen` feature

--- a/utils/frame/benchmarking-cli/Cargo.toml
+++ b/utils/frame/benchmarking-cli/Cargo.toml
@@ -15,8 +15,8 @@ targets = ["x86_64-unknown-linux-gnu"]
 [dependencies]
 frame-benchmarking = { version = "2.0.0", path = "../../../frame/benchmarking" }
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
-sc-service = { version = "0.8.0", default-features = false, path = "../../../client/service" }
-sc-cli = { version = "0.8.0", path = "../../../client/cli" }
+sc-service = { version = "0.8.0-chron.1", default-features = false, path = "../../../client/service" }
+sc-cli = { version = "0.8.0-chron.1", path = "../../../client/cli" }
 sc-client-db = { version = "0.8.0", path = "../../../client/db" }
 sc-executor = { version = "0.8.0", path = "../../../client/executor" }
 sp-externalities = { version = "0.8.0", path = "../../../primitives/externalities" }

--- a/utils/frame/frame-utilities-cli/Cargo.toml
+++ b/utils/frame/frame-utilities-cli/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 
 [dependencies]
 sp-core = { version = "2.0.0", path = "../../../primitives/core" }
-sc-cli = { version = "0.8.0", path = "../../../client/cli" }
+sc-cli = { version = "0.8.0-chron.1", path = "../../../client/cli" }
 sp-runtime = { version = "2.0.0", path = "../../../primitives/runtime" }
 structopt = "0.3.8"
 frame-system = { version = "2.0.0", path = "../../../frame/system" }


### PR DESCRIPTION
1. Add node-key-base64 flag to require base64 encoding of keys.
	modified:   client/cli/src/params/node_key_params.rs
2. Increase hard limit for inbound packets
	modified:   client/network/src/protocol/generic_proto/upgrade/legacy.rs
3. (To be discussed) Change the max number of blocks to notify at the same time.
	modified:   client/service/src/client/client.rs
